### PR TITLE
concurrent.future is deprecated in 2.11

### DIFF
--- a/src/main/scala/demo/SampleServiceActor.scala
+++ b/src/main/scala/demo/SampleServiceActor.scala
@@ -45,7 +45,7 @@ trait SampleRoute extends HttpService {
         } ~
         path("reactive") {
             get {
-                complete(future { "I'm reactive!" })
+                complete(Future { "I'm reactive!" })
             }
         } ~
         pathPrefix("junk") {


### PR DESCRIPTION
It'd be nice to make the sample code not be deprecated under the latest scala. The replacement, Future.apply, is not really any longer, and works in 2.10 too
